### PR TITLE
Add quark compat vertical slabs

### DIFF
--- a/src/main/java/group/rys/common/block/VerticalSlabBlock.java
+++ b/src/main/java/group/rys/common/block/VerticalSlabBlock.java
@@ -1,0 +1,163 @@
+package group.rys.common.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.IWaterLoggable;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.fluid.IFluidState;
+import net.minecraft.item.BlockItemUseContext;
+import net.minecraft.pathfinding.PathType;
+import net.minecraft.state.BooleanProperty;
+import net.minecraft.state.EnumProperty;
+import net.minecraft.state.StateContainer;
+import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.util.Direction;
+import net.minecraft.util.IStringSerializable;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.shapes.ISelectionContext;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.util.math.shapes.VoxelShapes;
+import net.minecraft.world.IBlockReader;
+import net.minecraft.world.IWorld;
+import net.minecraft.world.World;
+
+import javax.annotation.Nullable;
+
+public class VerticalSlabBlock extends Block implements IWaterLoggable {
+    public static final EnumProperty<VerticalSlabType> TYPE = EnumProperty.create("type", VerticalSlabType.class);
+    public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+
+    public VerticalSlabBlock(Properties properties)
+    {
+        super(properties);
+        this.setDefaultState(this.stateContainer.getBaseState().with(TYPE, VerticalSlabType.NORTH).with(WATERLOGGED, false));
+    }
+
+    @Override
+    protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder)
+    {
+        builder.add(TYPE, WATERLOGGED);
+    }
+
+    @Override
+    public boolean func_220074_n(BlockState state)
+    {
+        return state.get(TYPE) != VerticalSlabType.DOUBLE;
+    }
+
+    @Override
+    public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context)
+    {
+        return state.get(TYPE).getShape();
+    }
+
+    @Override
+    @Nullable
+    public BlockState getStateForPlacement(BlockItemUseContext context)
+    {
+        BlockPos pos = context.getPos();
+        World world = context.getWorld();
+        BlockState state = world.getBlockState(pos);
+        if(state.getBlock() == this) {
+            return state.with(TYPE, VerticalSlabType.DOUBLE).with(WATERLOGGED, false);
+        }
+        return this.getDefaultState().with(TYPE, VerticalSlabType.getSlabTypeByDirection(context.getPlacementHorizontalFacing().getOpposite())).with(WATERLOGGED, world.getFluidState(pos).getFluid().isIn(FluidTags.WATER));
+    }
+
+    @Override
+    public boolean isReplaceable(BlockState state, BlockItemUseContext context)
+    {
+        VerticalSlabType slabtype = state.get(TYPE);
+        return slabtype != VerticalSlabType.DOUBLE && context.getItem().getItem() == this.asItem() && context.replacingClickedOnBlock() && (context.getFace() == slabtype.slabDirection && context.getPlacementHorizontalFacing().getOpposite() == slabtype.slabDirection);
+    }
+
+
+    @Override
+    public IFluidState getFluidState(BlockState state)
+    {
+        return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : Fluids.EMPTY.getDefaultState();
+    }
+
+    @Override
+    public boolean receiveFluid(IWorld worldIn, BlockPos pos, BlockState state, IFluidState fluidStateIn)
+    {
+        return state.get(TYPE) != VerticalSlabType.DOUBLE && IWaterLoggable.super.receiveFluid(worldIn, pos, state, fluidStateIn);
+    }
+
+    @Override
+    public boolean canContainFluid(IBlockReader worldIn, BlockPos pos, BlockState state, Fluid fluidIn)
+    {
+        return state.get(TYPE) != VerticalSlabType.DOUBLE && IWaterLoggable.super.canContainFluid(worldIn, pos, state, fluidIn);
+    }
+
+    @Override
+    public BlockState updatePostPlacement(BlockState state, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos)
+    {
+        if(state.get(WATERLOGGED))
+        {
+            worldIn.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(worldIn));
+        }
+        return state;
+    }
+
+    @Override
+    public boolean allowsMovement(BlockState state, IBlockReader worldIn, BlockPos pos, PathType type)
+    {
+        return type == PathType.WATER && worldIn.getFluidState(pos).isTagged(FluidTags.WATER);
+    }
+
+    public static enum VerticalSlabType implements IStringSerializable
+    {
+        NORTH(Direction.NORTH),
+        SOUTH(Direction.SOUTH),
+        WEST(Direction.WEST),
+        EAST(Direction.EAST),
+        DOUBLE(null);
+
+        @Nullable
+        public final Direction slabDirection;
+
+        VerticalSlabType(@Nullable Direction slabDirection)
+        {
+            this.slabDirection = slabDirection;
+        }
+
+        public VoxelShape getShape()
+        {
+            if(this.slabDirection != null)
+            {
+                double minXZ = this.slabDirection.getAxisDirection() == Direction.AxisDirection.NEGATIVE ? 8 : 0;
+                double maxXZ = this.slabDirection.getAxisDirection() == Direction.AxisDirection.NEGATIVE ? 16 : 8;
+                return this.slabDirection.getAxis() == Direction.Axis.X ? Block.makeCuboidShape(minXZ, 0, 0, maxXZ, 16, 16) : Block.makeCuboidShape(0, 0, minXZ, 16, 16, maxXZ);
+            }
+            return VoxelShapes.fullCube();
+        }
+
+        @Nullable
+        public static VerticalSlabType getSlabTypeByDirection(@Nullable Direction direction)
+        {
+            for(VerticalSlabType types : VerticalSlabType.values())
+            {
+                if(types.slabDirection == direction)
+                {
+                    return types;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public String toString()
+        {
+            return this.slabDirection != null ? this.slabDirection.getName() : "double";
+        }
+
+        @Override
+        public String getName()
+        {
+            return this.toString();
+        }
+    }
+}

--- a/src/main/java/group/rys/core/registry/ModBlocks.java
+++ b/src/main/java/group/rys/core/registry/ModBlocks.java
@@ -10,9 +10,11 @@ import net.minecraft.block.WallBlock;
 import net.minecraft.item.Items;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.ObjectHolder;
+
 
 @Mod.EventBusSubscriber(modid = Reference.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
 @ObjectHolder(Reference.MOD_ID)
@@ -51,6 +53,12 @@ public class ModBlocks {
 	
 	public static final AnthillBlock anthill = create("anthill", new AnthillBlock(ModProperties.tough_dirt));
 	public static final HuntingAnthillBlock hunting_anthill = create("hunting_anthill", new HuntingAnthillBlock(ModProperties.tough_dirt));
+
+	public static final VerticalSlabBlock tough_dirt_vertical_slab = null;
+    public static final VerticalSlabBlock smooth_dirt_vertical_slab = null;
+    public static final VerticalSlabBlock mossy_tough_dirt_vertical_slab = null;
+    public static final VerticalSlabBlock dirt_bricks_vertical_slab = null;
+
 	
 	@SubscribeEvent
 	public static void registerBlocks(RegistryEvent.Register<Block> event) {
@@ -90,6 +98,15 @@ public class ModBlocks {
 		// TileEntities
 		registry.register(anthill);
 		registry.register(hunting_anthill);
+
+        if(ModList.get().isLoaded("quark"))
+        {
+            registry.register(create("tough_dirt_vertical_slab", new VerticalSlabBlock(ModProperties.tough_dirt)));
+            registry.register(create("smooth_dirt_vertical_slab", new VerticalSlabBlock(ModProperties.smooth_dirt)));
+            registry.register(create("mossy_tough_dirt_vertical_slab", new VerticalSlabBlock(ModProperties.mossy_tough_dirt)));
+            registry.register(create("dirt_bricks_vertical_slab", new VerticalSlabBlock(ModProperties.dirt_bricks)));
+
+        }
 	}
 
 	public static <T extends Block> T create(String name, T block) {

--- a/src/main/java/group/rys/core/registry/ModItems.java
+++ b/src/main/java/group/rys/core/registry/ModItems.java
@@ -8,6 +8,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.SpawnEggItem;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.ObjectHolder;
@@ -83,6 +84,15 @@ public class ModItems {
         registry.register(create("orange_fruit_sapling", new BlockItem(ModBlocks.orange_fruit_sapling, ModProperties.item)));
         registry.register(create("apricot_fruit_sapling", new BlockItem(ModBlocks.apricot_fruit_sapling, ModProperties.item)));
 		registry.register(create("dayroot", new BlockItem(ModBlocks.dayroot, ModProperties.item)));
+
+		// QuarkBlocks
+		if(ModList.get().isLoaded("quark"))
+		{
+			registry.register(create("tough_dirt_vertical_slab", new BlockItem(ModBlocks.tough_dirt_vertical_slab, ModProperties.item)));
+			registry.register(create("smooth_dirt_vertical_slab", new BlockItem(ModBlocks.smooth_dirt_vertical_slab, ModProperties.item)));
+			registry.register(create("mossy_tough_dirt_vertical_slab", new BlockItem(ModBlocks.mossy_tough_dirt_vertical_slab, ModProperties.item)));
+			registry.register(create("dirt_bricks_vertical_slab", new BlockItem(ModBlocks.dirt_bricks_vertical_slab, ModProperties.item)));
+		}
 		
 		// TileEntities
 		registry.register(create("anthill", new BlockItem(ModBlocks.anthill, ModProperties.item)));

--- a/src/main/resources/assets/rys/blockstates/dirt_bricks_vertical_slab.json
+++ b/src/main/resources/assets/rys/blockstates/dirt_bricks_vertical_slab.json
@@ -1,0 +1,9 @@
+{
+    "variants": {
+        "type=north": { "model": "rys:block/dirt_bricks_vertical_slab", "y": 0, "uvlock": true },
+        "type=south": { "model": "rys:block/dirt_bricks_vertical_slab", "y": 180, "uvlock": true },
+        "type=east": { "model": "rys:block/dirt_bricks_vertical_slab", "y": 90, "uvlock": true },
+        "type=west": { "model": "rys:block/dirt_bricks_vertical_slab", "y": 270, "uvlock": true },
+        "type=double": { "model": "rys:block/dirt_bricks" }
+    }
+}

--- a/src/main/resources/assets/rys/blockstates/mossy_tough_dirt_vertical_slab.json
+++ b/src/main/resources/assets/rys/blockstates/mossy_tough_dirt_vertical_slab.json
@@ -1,0 +1,9 @@
+{
+    "variants": {
+        "type=north": { "model": "rys:block/mossy_tough_dirt_vertical_slab", "y": 0, "uvlock": true },
+        "type=south": { "model": "rys:block/mossy_tough_dirt_vertical_slab", "y": 180, "uvlock": true },
+        "type=east": { "model": "rys:block/mossy_tough_dirt_vertical_slab", "y": 90, "uvlock": true },
+        "type=west": { "model": "rys:block/mossy_tough_dirt_vertical_slab", "y": 270, "uvlock": true },
+        "type=double": { "model": "rys:block/mossy_tough_dirt" }
+    }
+}

--- a/src/main/resources/assets/rys/blockstates/smooth_dirt_vertical_slab.json
+++ b/src/main/resources/assets/rys/blockstates/smooth_dirt_vertical_slab.json
@@ -1,0 +1,9 @@
+{
+    "variants": {
+        "type=north": { "model": "rys:block/smooth_dirt_vertical_slab", "y": 0, "uvlock": true },
+        "type=south": { "model": "rys:block/smooth_dirt_vertical_slab", "y": 180, "uvlock": true },
+        "type=east": { "model": "rys:block/smooth_dirt_vertical_slab", "y": 90, "uvlock": true },
+        "type=west": { "model": "rys:block/smooth_dirt_vertical_slab", "y": 270, "uvlock": true },
+        "type=double": { "model": "rys:block/smooth_dirt" }
+    }
+}

--- a/src/main/resources/assets/rys/blockstates/tough_dirt_vertical_slab.json
+++ b/src/main/resources/assets/rys/blockstates/tough_dirt_vertical_slab.json
@@ -1,0 +1,9 @@
+{
+    "variants": {
+        "type=north": { "model": "rys:block/tough_dirt_vertical_slab", "y": 0, "uvlock": true },
+        "type=south": { "model": "rys:block/tough_dirt_vertical_slab", "y": 180, "uvlock": true },
+        "type=east": { "model": "rys:block/tough_dirt_vertical_slab", "y": 90, "uvlock": true },
+        "type=west": { "model": "rys:block/tough_dirt_vertical_slab", "y": 270, "uvlock": true },
+        "type=double": { "model": "rys:block/tough_dirt" }
+    }
+}

--- a/src/main/resources/assets/rys/lang/en_us.json
+++ b/src/main/resources/assets/rys/lang/en_us.json
@@ -26,6 +26,11 @@
 	"block.rys.orange_fruit_sapling": "Orange Fruit Sapling",
 	"block.rys.apricot_fruit_sapling": "Apricot Fruit Sapling",
 	"block.rys.dayroot": "Dayroot",
+
+	"block.rys.tough_dirt_vertical_slab": "Tough Dirt Vertical Slab",
+	"block.rys.mossy_tough_dirt_vertical_slab": "Mossy Tough Dirt Vertical Slab",
+	"block.rys.smooth_dirt_vertical_slab": "Smooth Dirt Vertical Slab",
+	"block.rys.dirt_bricks_vertical_slab": "Dirt Bricks Vertical Slab",
 	
 	"item.rys.peat": "Peat",
 	"item.rys.orange": "Orange",

--- a/src/main/resources/assets/rys/models/block/dirt_bricks_vertical_slab.json
+++ b/src/main/resources/assets/rys/models/block/dirt_bricks_vertical_slab.json
@@ -1,0 +1,8 @@
+{
+    "parent": "rys:block/vertical_slab",
+    "textures": {
+        "side": "rys:block/dirt_bricks",
+        "top": "rys:block/dirt_bricks",
+        "bottom": "rys:block/dirt_bricks"
+    }
+}

--- a/src/main/resources/assets/rys/models/block/mossy_tough_dirt_vertical_slab.json
+++ b/src/main/resources/assets/rys/models/block/mossy_tough_dirt_vertical_slab.json
@@ -1,0 +1,8 @@
+{
+    "parent": "rys:block/vertical_slab",
+    "textures": {
+        "side": "rys:block/mossy_tough_dirt",
+        "top": "rys:block/mossy_tough_dirt",
+        "bottom": "rys:block/mossy_tough_dirt"
+    }
+}

--- a/src/main/resources/assets/rys/models/block/smooth_dirt_vertical_slab.json
+++ b/src/main/resources/assets/rys/models/block/smooth_dirt_vertical_slab.json
@@ -1,0 +1,8 @@
+{
+    "parent": "rys:block/vertical_slab",
+    "textures": {
+        "side": "rys:block/smooth_dirt",
+        "top": "rys:block/smooth_dirt",
+        "bottom": "rys:block/smooth_dirt"
+    }
+}

--- a/src/main/resources/assets/rys/models/block/tough_dirt_vertical_slab.json
+++ b/src/main/resources/assets/rys/models/block/tough_dirt_vertical_slab.json
@@ -1,0 +1,8 @@
+{
+    "parent": "rys:block/vertical_slab",
+    "textures": {
+        "side": "rys:block/tough_dirt",
+        "top": "rys:block/tough_dirt",
+        "bottom": "rys:block/tough_dirt"
+    }
+}

--- a/src/main/resources/assets/rys/models/block/vertical_slab.json
+++ b/src/main/resources/assets/rys/models/block/vertical_slab.json
@@ -1,0 +1,18 @@
+{   "parent": "block/block",
+    "textures": {
+        "particle": "#side"
+    },
+    "elements": [
+        {   "from": [ 0, 0, 8 ],
+            "to": [ 16, 16, 16 ],
+            "faces": {
+                "down":  { "uv": [ 0, 8, 16, 16 ], "texture": "#bottom", "cullface": "down" },
+                "up":    { "uv": [ 0, 8, 16, 16 ], "texture": "#top", "cullface": "up" },
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#side" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
+                "west":  { "uv": [ 8, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
+                "east":  { "uv": [ 8, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/rys/models/item/dirt_bricks_vertical_slab.json
+++ b/src/main/resources/assets/rys/models/item/dirt_bricks_vertical_slab.json
@@ -1,0 +1,3 @@
+{
+    "parent": "rys:block/dirt_bricks_vertical_slab"
+}

--- a/src/main/resources/assets/rys/models/item/mossy_tough_dirt_vertical_slab.json
+++ b/src/main/resources/assets/rys/models/item/mossy_tough_dirt_vertical_slab.json
@@ -1,0 +1,3 @@
+{
+    "parent": "rys:block/mossy_tough_dirt_vertical_slab"
+}

--- a/src/main/resources/assets/rys/models/item/smooth_dirt_vertical_slab.json
+++ b/src/main/resources/assets/rys/models/item/smooth_dirt_vertical_slab.json
@@ -1,0 +1,3 @@
+{
+    "parent": "rys:block/smooth_dirt_vertical_slab"
+}

--- a/src/main/resources/assets/rys/models/item/tough_dirt_vertical_slab.json
+++ b/src/main/resources/assets/rys/models/item/tough_dirt_vertical_slab.json
@@ -1,0 +1,3 @@
+{
+    "parent": "rys:block/tough_dirt_vertical_slab"
+}

--- a/src/main/resources/data/rys/loot_tables/blocks/dirt_bricks_vertical_slab.json
+++ b/src/main/resources/data/rys/loot_tables/blocks/dirt_bricks_vertical_slab.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "rys:match_harvest_level",
+              "harvest_level": 1
+            },
+            {
+              "condition": "rys:match_harvest_tool",
+              "harvest_tool": "shovel"
+            }
+          ],
+          "name": "rys:dirt_bricks_vertical_slab"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/rys/loot_tables/blocks/mossy_tough_dirt_vertical_slab.json
+++ b/src/main/resources/data/rys/loot_tables/blocks/mossy_tough_dirt_vertical_slab.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "rys:match_harvest_level",
+              "harvest_level": 1
+            },
+            {
+              "condition": "rys:match_harvest_tool",
+              "harvest_tool": "shovel"
+            }
+          ],
+          "name": "rys:mossy_tough_dirt_vertical_slab"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/rys/loot_tables/blocks/smooth_dirt_vertical_slab.json
+++ b/src/main/resources/data/rys/loot_tables/blocks/smooth_dirt_vertical_slab.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "rys:match_harvest_level",
+              "harvest_level": 1
+            },
+            {
+              "condition": "rys:match_harvest_tool",
+              "harvest_tool": "shovel"
+            }
+          ],
+          "name": "rys:smooth_dirt_vertical_slab"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/rys/loot_tables/blocks/tough_dirt_vertical_slab.json
+++ b/src/main/resources/data/rys/loot_tables/blocks/tough_dirt_vertical_slab.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "rys:match_harvest_level",
+              "harvest_level": 1
+            },
+            {
+              "condition": "rys:match_harvest_tool",
+              "harvest_tool": "shovel"
+            }
+          ],
+          "name": "rys:tough_dirt_vertical_slab"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/rys/recipes/dirt_bricks_vertical_slab.json
+++ b/src/main/resources/data/rys/recipes/dirt_bricks_vertical_slab.json
@@ -1,0 +1,17 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"pattern": [
+		"A",
+		"A",
+		"A"
+	],
+	"key": {
+		"A": {
+			"item": "rys:dirt_bricks_slab"
+		}
+	},
+	"result": {
+		"item": "rys:dirt_bricks_vertical_slab",
+		"count": 3
+	}
+}

--- a/src/main/resources/data/rys/recipes/mossy_tough_dirt_vertical_slab.json
+++ b/src/main/resources/data/rys/recipes/mossy_tough_dirt_vertical_slab.json
@@ -1,0 +1,17 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"pattern": [
+		"A",
+		"A",
+		"A"
+	],
+	"key": {
+		"A": {
+			"item": "rys:mossy_tough_dirt_slab"
+		}
+	},
+	"result": {
+		"item": "rys:mossy_tough_dirt_vertical_slab",
+		"count": 3
+	}
+}

--- a/src/main/resources/data/rys/recipes/smooth_dirt_vertical_slab.json
+++ b/src/main/resources/data/rys/recipes/smooth_dirt_vertical_slab.json
@@ -1,0 +1,17 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"pattern": [
+		"A",
+		"A",
+		"A"
+	],
+	"key": {
+		"A": {
+			"item": "rys:smooth_dirt_slab"
+		}
+	},
+	"result": {
+		"item": "rys:smooth_dirt_vertical_slab",
+		"count": 3
+	}
+}

--- a/src/main/resources/data/rys/recipes/tough_dirt_vertical_slab.json
+++ b/src/main/resources/data/rys/recipes/tough_dirt_vertical_slab.json
@@ -1,0 +1,17 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"pattern": [
+		"A",
+		"A",
+		"A"
+	],
+	"key": {
+		"A": {
+			"item": "rys:tough_dirt_slab"
+		}
+	},
+	"result": {
+		"item": "rys:tough_dirt_vertical_slab",
+		"count": 3
+	}
+}


### PR DESCRIPTION
add quark compat of 4 different blocks:
+ tough dirt vertical slab
+ mossy tough dirt vertical slab
+ smooth dirt vertical slab
+ dirt brick vertical slab
the blocks are only registered when quark is loaded.
NOTE: ru_ru and es_es lang files do not yet support those  new blocks.